### PR TITLE
Update the contrib guidelines

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -39,3 +39,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 ## Attribution
 
 This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+## Working with the Project Team
+
+The core project contributors are based in the Philippines. To join our private group chat on facebook, please file an issue stating your facebook username to join the group.


### PR DESCRIPTION
Add a note on how to join the Fb group chat. I think this is the best way - feel free to -1 if this is not the best way to get someone on board - like alternatives are to form a slack group instead perhaps ?.